### PR TITLE
Add GitHub Action for RSS feed generation

### DIFF
--- a/.github/scripts/generate_rss.py
+++ b/.github/scripts/generate_rss.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate an RSS feed of .torrent links from README.md."""
+
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def extract_torrent_entries(readme_path: str) -> list[tuple[str, str, str]]:
+    """Extract torrent entries from README.md.
+
+    Returns list of (log_origin, archive_url, torrent_url) tuples.
+    """
+    content = Path(readme_path).read_text()
+    entries = []
+
+    # Match table rows with torrent links
+    # Format: | log_origin | archive_url | [.torrent](torrent_url) |
+    pattern = r'\|\s*([^\|]+?)\s*\|\s*(https://[^\s\|]+)\s*[†]?\s*\|\s*\[\.torrent\]\(([^)]+)\)\s*\|'
+
+    for match in re.finditer(pattern, content):
+        log_origin = match.group(1).strip()
+        archive_url = match.group(2).strip()
+        torrent_url = match.group(3).strip()
+        entries.append((log_origin, archive_url, torrent_url))
+
+    return entries
+
+
+def generate_rss(entries: list[tuple[str, str, str]], output_path: str) -> None:
+    """Generate RSS feed from torrent entries."""
+    # Register namespace to avoid ns0 prefix
+    ET.register_namespace('atom', 'http://www.w3.org/2005/Atom')
+
+    rss = ET.Element('rss', version='2.0')
+
+    channel = ET.SubElement(rss, 'channel')
+
+    # Channel metadata
+    title = ET.SubElement(channel, 'title')
+    title.text = 'CT Log Archive Torrents'
+
+    link = ET.SubElement(channel, 'link')
+    link.text = 'https://github.com/geomys/ct-archive'
+
+    description = ET.SubElement(channel, 'description')
+    description.text = 'Torrent files for archived Certificate Transparency logs'
+
+    language = ET.SubElement(channel, 'language')
+    language.text = 'en-us'
+
+    # Last build date
+    last_build = ET.SubElement(channel, 'lastBuildDate')
+    last_build.text = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S +0000')
+
+    # Self-referencing atom:link
+    atom_link = ET.SubElement(channel, '{http://www.w3.org/2005/Atom}link')
+    atom_link.set('href', 'https://raw.githubusercontent.com/geomys/ct-archive/main/torrents.rss')
+    atom_link.set('rel', 'self')
+    atom_link.set('type', 'application/rss+xml')
+
+    # Add items for each torrent
+    for log_origin, archive_url, torrent_url in entries:
+        item = ET.SubElement(channel, 'item')
+
+        item_title = ET.SubElement(item, 'title')
+        item_title.text = f'{log_origin}'
+
+        item_link = ET.SubElement(item, 'link')
+        item_link.text = archive_url
+
+        item_description = ET.SubElement(item, 'description')
+        item_description.text = f'Torrent archive for CT log: {log_origin}'
+
+        # Use torrent URL as enclosure
+        enclosure = ET.SubElement(item, 'enclosure')
+        enclosure.set('url', torrent_url)
+        enclosure.set('type', 'application/x-bittorrent')
+
+        # Use torrent URL as guid
+        guid = ET.SubElement(item, 'guid')
+        guid.set('isPermaLink', 'false')
+        guid.text = torrent_url
+
+    # Write with XML declaration
+    tree = ET.ElementTree(rss)
+    ET.indent(tree, space='  ')
+    tree.write(output_path, encoding='unicode', xml_declaration=True)
+
+    # Add newline at end of file
+    with open(output_path, 'a') as f:
+        f.write('\n')
+
+
+def main():
+    readme_path = Path(__file__).parent.parent.parent / 'README.md'
+    output_path = Path(__file__).parent.parent.parent / 'torrents.rss'
+
+    entries = extract_torrent_entries(str(readme_path))
+    print(f'Found {len(entries)} torrent entries')
+
+    generate_rss(entries, str(output_path))
+    print(f'Generated RSS feed at {output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/generate-rss.yml
+++ b/.github/workflows/generate-rss.yml
@@ -1,0 +1,35 @@
+name: Generate RSS Feed
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-rss:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate RSS feed
+        run: python .github/scripts/generate_rss.py
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add torrents.rss
+          git diff --staged --quiet || git commit -m 'Update RSS feed'
+          git push

--- a/torrents.rss
+++ b/torrents.rss
@@ -1,0 +1,326 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <title>CT Log Archive Torrents</title>
+    <link>https://github.com/geomys/ct-archive</link>
+    <description>Torrent files for archived Certificate Transparency logs</description>
+    <language>en-us</language>
+    <lastBuildDate>Wed, 17 Dec 2025 15:42:12 +0000</lastBuildDate>
+    <atom:link href="https://raw.githubusercontent.com/geomys/ct-archive/main/torrents.rss" rel="self" type="application/rss+xml" />
+    <item>
+      <title>ct.cloudflare.com/logs/nimbus2022</title>
+      <link>https://archive.org/details/ct_cloudflare_nimbus2022</link>
+      <description>Torrent archive for CT log: ct.cloudflare.com/logs/nimbus2022</description>
+      <enclosure url="https://archive.org/download/ct_cloudflare_nimbus2022/ct_cloudflare_nimbus2022_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_cloudflare_nimbus2022/ct_cloudflare_nimbus2022_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct.cloudflare.com/logs/nimbus2023</title>
+      <link>https://archive.org/details/ct_cloudflare_nimbus2023</link>
+      <description>Torrent archive for CT log: ct.cloudflare.com/logs/nimbus2023</description>
+      <enclosure url="https://archive.org/download/ct_cloudflare_nimbus2023/ct_cloudflare_nimbus2023_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_cloudflare_nimbus2023/ct_cloudflare_nimbus2023_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct.cloudflare.com/logs/nimbus2024</title>
+      <link>https://archive.org/details/ct_cloudflare_nimbus2024</link>
+      <description>Torrent archive for CT log: ct.cloudflare.com/logs/nimbus2024</description>
+      <enclosure url="https://archive.org/download/ct_cloudflare_nimbus2024/ct_cloudflare_nimbus2024_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_cloudflare_nimbus2024/ct_cloudflare_nimbus2024_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct1.digicert-ct.com/log</title>
+      <link>https://archive.org/details/ct_digicert_ct1</link>
+      <description>Torrent archive for CT log: ct1.digicert-ct.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_ct1/ct_digicert_ct1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_ct1/ct_digicert_ct1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct2.digicert-ct.com/log</title>
+      <link>https://archive.org/details/ct_digicert_ct2</link>
+      <description>Torrent archive for CT log: ct2.digicert-ct.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_ct2/ct_digicert_ct2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_ct2/ct_digicert_ct2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2018.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2018</link>
+      <description>Torrent archive for CT log: yeti2018.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2018/ct_digicert_yeti2018_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2018/ct_digicert_yeti2018_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2019.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2019</link>
+      <description>Torrent archive for CT log: yeti2019.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2019/ct_digicert_yeti2019_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2019/ct_digicert_yeti2019_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2020.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2020</link>
+      <description>Torrent archive for CT log: yeti2020.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2020/ct_digicert_yeti2020_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2020/ct_digicert_yeti2020_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2021.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2021</link>
+      <description>Torrent archive for CT log: yeti2021.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2021/ct_digicert_yeti2021_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2021/ct_digicert_yeti2021_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2022.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2022</link>
+      <description>Torrent archive for CT log: yeti2022.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2022/ct_digicert_yeti2022_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2022/ct_digicert_yeti2022_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2022-2.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2022_2</link>
+      <description>Torrent archive for CT log: yeti2022-2.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2022_2/ct_digicert_yeti2022_2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2022_2/ct_digicert_yeti2022_2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>yeti2023.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_yeti2023</link>
+      <description>Torrent archive for CT log: yeti2023.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_yeti2023/ct_digicert_yeti2023_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_yeti2023/ct_digicert_yeti2023_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2018.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2018</link>
+      <description>Torrent archive for CT log: nessie2018.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2018/ct_digicert_nessie2018_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2018/ct_digicert_nessie2018_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2019.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2019</link>
+      <description>Torrent archive for CT log: nessie2019.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2019/ct_digicert_nessie2019_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2019/ct_digicert_nessie2019_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2020.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2020</link>
+      <description>Torrent archive for CT log: nessie2020.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2020/ct_digicert_nessie2020_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2020/ct_digicert_nessie2020_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2021.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2021</link>
+      <description>Torrent archive for CT log: nessie2021.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2021/ct_digicert_nessie2021_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2021/ct_digicert_nessie2021_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2022.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2022</link>
+      <description>Torrent archive for CT log: nessie2022.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2022/ct_digicert_nessie2022_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2022/ct_digicert_nessie2022_archive.torrent</guid>
+    </item>
+    <item>
+      <title>nessie2023.ct.digicert.com/log</title>
+      <link>https://archive.org/details/ct_digicert_nessie2023</link>
+      <description>Torrent archive for CT log: nessie2023.ct.digicert.com/log</description>
+      <enclosure url="https://archive.org/download/ct_digicert_nessie2023/ct_digicert_nessie2023_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_nessie2023/ct_digicert_nessie2023_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sphinx.ct.digicert.com/2024h1</title>
+      <link>https://archive.org/details/ct_digicert_sphinx2024h1</link>
+      <description>Torrent archive for CT log: sphinx.ct.digicert.com/2024h1</description>
+      <enclosure url="https://archive.org/download/ct_digicert_sphinx2024h1/ct_digicert_sphinx2024h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_sphinx2024h1/ct_digicert_sphinx2024h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sphinx.ct.digicert.com/2024h2</title>
+      <link>https://archive.org/details/ct_digicert_sphinx2024h2</link>
+      <description>Torrent archive for CT log: sphinx.ct.digicert.com/2024h2</description>
+      <enclosure url="https://archive.org/download/ct_digicert_sphinx2024h2/ct_digicert_sphinx2024h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_sphinx2024h2/ct_digicert_sphinx2024h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>wyvern.ct.digicert.com/2024h1</title>
+      <link>https://archive.org/details/ct_digicert_wyvern2024h1</link>
+      <description>Torrent archive for CT log: wyvern.ct.digicert.com/2024h1</description>
+      <enclosure url="https://archive.org/download/ct_digicert_wyvern2024h1/ct_digicert_wyvern2024h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_wyvern2024h1/ct_digicert_wyvern2024h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>wyvern.ct.digicert.com/2024h2</title>
+      <link>https://archive.org/details/ct_digicert_wyvern2024h2</link>
+      <description>Torrent archive for CT log: wyvern.ct.digicert.com/2024h2</description>
+      <enclosure url="https://archive.org/download/ct_digicert_wyvern2024h2/ct_digicert_wyvern2024h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_digicert_wyvern2024h2/ct_digicert_wyvern2024h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct.ws.symantec.com</title>
+      <link>https://archive.org/details/ct_symantec_ct</link>
+      <description>Torrent archive for CT log: ct.ws.symantec.com</description>
+      <enclosure url="https://archive.org/download/ct_symantec_ct/ct_symantec_ct_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_symantec_ct/ct_symantec_ct_archive.torrent</guid>
+    </item>
+    <item>
+      <title>vega.ws.symantec.com</title>
+      <link>https://archive.org/details/ct_symantec_vega</link>
+      <description>Torrent archive for CT log: vega.ws.symantec.com</description>
+      <enclosure url="https://archive.org/download/ct_symantec_vega/ct_symantec_vega_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_symantec_vega/ct_symantec_vega_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sirius.ws.symantec.com</title>
+      <link>https://archive.org/details/ct_symantec_sirius</link>
+      <description>Torrent archive for CT log: sirius.ws.symantec.com</description>
+      <enclosure url="https://archive.org/download/ct_symantec_sirius/ct_symantec_sirius_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_symantec_sirius/ct_symantec_sirius_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ctlog-gen2.api.venafi.com</title>
+      <link>https://archive.org/details/ct_venafi_ctlog_gen2</link>
+      <description>Torrent archive for CT log: ctlog-gen2.api.venafi.com</description>
+      <enclosure url="https://archive.org/download/ct_venafi_ctlog_gen2/ct_venafi_ctlog_gen2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_venafi_ctlog_gen2/ct_venafi_ctlog_gen2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2019</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2019</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2019</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2019/ct_letsencrypt_oak2019_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2019/ct_letsencrypt_oak2019_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2020</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2020</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2020</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2020/ct_letsencrypt_oak2020_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2020/ct_letsencrypt_oak2020_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2021</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2021</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2021</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2021/ct_letsencrypt_oak2021_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2021/ct_letsencrypt_oak2021_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2022</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2022</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2022</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2022/ct_letsencrypt_oak2022_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2022/ct_letsencrypt_oak2022_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2023</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2023</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2023</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2023/ct_letsencrypt_oak2023_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2023/ct_letsencrypt_oak2023_archive.torrent</guid>
+    </item>
+    <item>
+      <title>oak.ct.letsencrypt.org/2025h1</title>
+      <link>https://archive.org/details/ct_letsencrypt_oak2025h1</link>
+      <description>Torrent archive for CT log: oak.ct.letsencrypt.org/2025h1</description>
+      <enclosure url="https://archive.org/download/ct_letsencrypt_oak2025h1/ct_letsencrypt_oak2025h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_letsencrypt_oak2025h1/ct_letsencrypt_oak2025h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre.ct.comodo.com</title>
+      <link>https://archive.org/details/ct_comodo_sabre</link>
+      <description>Torrent archive for CT log: sabre.ct.comodo.com</description>
+      <enclosure url="https://archive.org/download/ct_comodo_sabre/ct_comodo_sabre_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_comodo_sabre/ct_comodo_sabre_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth.ct.comodo.com</title>
+      <link>https://archive.org/details/ct_comodo_mammoth</link>
+      <description>Torrent archive for CT log: mammoth.ct.comodo.com</description>
+      <enclosure url="https://archive.org/download/ct_comodo_mammoth/ct_comodo_mammoth_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_comodo_mammoth/ct_comodo_mammoth_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth2024h1.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_mammoth2024h1</link>
+      <description>Torrent archive for CT log: mammoth2024h1.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_mammoth2024h1/ct_sectigo_mammoth2024h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_mammoth2024h1/ct_sectigo_mammoth2024h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth2024h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_mammoth2024h2</link>
+      <description>Torrent archive for CT log: mammoth2024h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_mammoth2024h2/ct_sectigo_mammoth2024h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_mammoth2024h2/ct_sectigo_mammoth2024h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth2025h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_mammoth2025h2</link>
+      <description>Torrent archive for CT log: mammoth2025h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_mammoth2025h2/ct_sectigo_mammoth2025h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_mammoth2025h2/ct_sectigo_mammoth2025h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth2026h1.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_mammoth2026h1</link>
+      <description>Torrent archive for CT log: mammoth2026h1.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_mammoth2026h1/ct_sectigo_mammoth2026h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_mammoth2026h1/ct_sectigo_mammoth2026h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>mammoth2026h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_mammoth2026h2</link>
+      <description>Torrent archive for CT log: mammoth2026h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_mammoth2026h2/ct_sectigo_mammoth2026h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_mammoth2026h2/ct_sectigo_mammoth2026h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre2024h1.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_sabre2024h1</link>
+      <description>Torrent archive for CT log: sabre2024h1.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_sabre2024h1/ct_sectigo_sabre2024h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_sabre2024h1/ct_sectigo_sabre2024h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre2024h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_sabre2024h2</link>
+      <description>Torrent archive for CT log: sabre2024h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_sabre2024h2/ct_sectigo_sabre2024h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_sabre2024h2/ct_sectigo_sabre2024h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre2025h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_sabre2025h2</link>
+      <description>Torrent archive for CT log: sabre2025h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_sabre2025h2/ct_sectigo_sabre2025h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_sabre2025h2/ct_sectigo_sabre2025h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre2026h1.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_sabre2026h1</link>
+      <description>Torrent archive for CT log: sabre2026h1.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_sabre2026h1/ct_sectigo_sabre2026h1_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_sabre2026h1/ct_sectigo_sabre2026h1_archive.torrent</guid>
+    </item>
+    <item>
+      <title>sabre2026h2.ct.sectigo.com</title>
+      <link>https://archive.org/details/ct_sectigo_sabre2026h2</link>
+      <description>Torrent archive for CT log: sabre2026h2.ct.sectigo.com</description>
+      <enclosure url="https://archive.org/download/ct_sectigo_sabre2026h2/ct_sectigo_sabre2026h2_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_sectigo_sabre2026h2/ct_sectigo_sabre2026h2_archive.torrent</guid>
+    </item>
+    <item>
+      <title>ct2024.trustasia.com/log2024</title>
+      <link>https://archive.org/details/ct_trustasia_log2024</link>
+      <description>Torrent archive for CT log: ct2024.trustasia.com/log2024</description>
+      <enclosure url="https://archive.org/download/ct_trustasia_log2024/ct_trustasia_log2024_archive.torrent" type="application/x-bittorrent" />
+      <guid isPermaLink="false">https://archive.org/download/ct_trustasia_log2024/ct_trustasia_log2024_archive.torrent</guid>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
- Add generate_rss.py script to parse README.md and extract torrent links
- Add generate-rss.yml workflow that runs on push to main when README.md changes
- Generate initial torrents.rss with all 45 current torrent entries