### PR TITLE
Trim final slash from baseURL

### DIFF
--- a/cmd/vanity-mirror/vanity-mirror.go
+++ b/cmd/vanity-mirror/vanity-mirror.go
@@ -95,6 +95,7 @@ func main() {
 	if len(os.Args) == 2 {
 		baseURL = os.Args[1]
 	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
 	logger.Info("starting mirror", "origin", origin, "base_url", baseURL)
 
 	client := &http.Client{


### PR DESCRIPTION
Was useful for `digicert_yeti2025` and `digicert_nessie2025` (#6/#8) because those servers rejected requests with duplicate slashes in paths.