### PR TITLE
Add new entries for elephant2026h1 and tiger2026h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ logs, as well as tools to archive RFC 6962 and Static CT logs.
 | sabre2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_sabre2026h1 † | [.torrent](https://archive.org/download/ct_sectigo_sabre2026h1/ct_sectigo_sabre2026h1_archive.torrent) |
 | sabre2026h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_sabre2026h2 † | [.torrent](https://archive.org/download/ct_sectigo_sabre2026h2/ct_sectigo_sabre2026h2_archive.torrent) |
 | elephant2025h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_elephant2025h2 |
+| elephant2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_elephant2026h1 and https://archive.org/details/ct_sectigo_elephant2026h1_ext1 |
 | tiger2025h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_tiger2025h2 |
+| tiger2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_tiger2026h1 and https://archive.org/details/ct_sectigo_tiger2026h1_ext1 |
 | ct2025-a.trustasia.com/log2025a | https://archive.org/details/ct_trustasia_log2025a ||
 | ct2025-b.trustasia.com/log2025b | https://archive.org/details/ct_trustasia_log2025b ||
 | ct2024.trustasia.com/log2024 | https://archive.org/details/ct_trustasia_log2024 | [.torrent](https://archive.org/download/ct_trustasia_log2024/ct_trustasia_log2024_archive.torrent) |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ logs, as well as tools to archive RFC 6962 and Static CT logs.
 | sabre2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_sabre2026h1 † | [.torrent](https://archive.org/download/ct_sectigo_sabre2026h1/ct_sectigo_sabre2026h1_archive.torrent) |
 | sabre2026h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_sabre2026h2 † | [.torrent](https://archive.org/download/ct_sectigo_sabre2026h2/ct_sectigo_sabre2026h2_archive.torrent) |
 | elephant2025h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_elephant2025h2 |
-| elephant2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_elephant2026h1 and https://archive.org/details/ct_sectigo_elephant2026h1_ext1 |
+| elephant2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_elephant2026h1 https://archive.org/details/ct_sectigo_elephant2026h1_ext1 |
 | tiger2025h2.ct.sectigo.com | https://archive.org/details/ct_sectigo_tiger2025h2 |
-| tiger2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_tiger2026h1 and https://archive.org/details/ct_sectigo_tiger2026h1_ext1 |
+| tiger2026h1.ct.sectigo.com | https://archive.org/details/ct_sectigo_tiger2026h1 https://archive.org/details/ct_sectigo_tiger2026h1_ext1 |
 | ct2025-a.trustasia.com/log2025a | https://archive.org/details/ct_trustasia_log2025a ||
 | ct2025-b.trustasia.com/log2025b | https://archive.org/details/ct_trustasia_log2025b ||
 | ct2024.trustasia.com/log2024 | https://archive.org/details/ct_trustasia_log2024 | [.torrent](https://archive.org/download/ct_trustasia_log2024/ct_trustasia_log2024_archive.torrent) |


### PR DESCRIPTION
I had to split these into two parts, due to hitting the Internet Archive's 1TB limit.

The `uv run --script cmd/ia-metadata.py $ITEM` step succeeded for the first parts `sectigo_tiger2026h1` and `sectigo_elephant2026h1`, but it failed for the extra parts:

```
Fetching current metadata for item ct_sectigo_elephant2026h1_ext1...
Fetching checkpoint and log info...
Traceback (most recent call last):
  File "/root/git/ct-archive/cmd/ia-metadata.py", line 129, in <module>
    main()
  File "/root/git/ct-archive/cmd/ia-metadata.py", line 67, in main
    checkpoint_resp.raise_for_status()
  File "/root/.cache/uv/environments-v2/ia-metadata-c5313b96bca2dfe4/lib/python3.8/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://archive.org/about/404.php
```

```
Fetching current metadata for item ct_sectigo_tiger2026h1_ext1...
Fetching checkpoint and log info...
Traceback (most recent call last):
  File "/root/git/ct-archive/cmd/ia-metadata.py", line 129, in <module>
    main()
  File "/root/git/ct-archive/cmd/ia-metadata.py", line 67, in main
    checkpoint_resp.raise_for_status()
  File "/root/.cache/uv/environments-v2/ia-metadata-c5313b96bca2dfe4/lib/python3.8/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://archive.org/about/404.php
```

